### PR TITLE
ES6 import URL vervangen door dynamisch inladen en E2E testen alleen draaien tijdens de werkdagen en kantooruren

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,6 +51,6 @@
   },
   "devDependencies": {
     "@govflanders/vl-ui-util": "3.9.1",
-    "vl-ui-util": "^5.0.7"
+    "vl-ui-util": "^5.0.8"
   }
 }

--- a/src/vl-footer.js
+++ b/src/vl-footer.js
@@ -1,5 +1,8 @@
-import { VlElement, define } from '/node_modules/vl-ui-core/dist/vl-core.js';
-import 'https://prod.widgets.burgerprofiel.vlaanderen.be/api/v1/node_modules/@govflanders/vl-widget-polyfill/dist/index.js';
+import { VlElement, define, awaitScript } from '/node_modules/vl-ui-core/dist/vl-core.js';
+
+awaitScript('vl-footer', 'https://prod.widgets.burgerprofiel.vlaanderen.be/api/v1/node_modules/@govflanders/vl-widget-polyfill/dist/index.js').then(() => {
+    define('vl-footer', VlFooter);
+});
 
 /**
  * VlFooter
@@ -61,5 +64,3 @@ export class VlFooter extends VlElement(HTMLElement) {
         eval(code.replace(/document\.write\((.*?)\);/, 'document.getElementById("' + VlFooter.id + '").innerHTML = $1;'));
     }
 }
-
-define('vl-footer', VlFooter);

--- a/test/e2e/footer.test.js
+++ b/test/e2e/footer.test.js
@@ -9,8 +9,22 @@ describe('vl-footer', async () => {
         return vlFooterPage.load();
     });
 
+    const isDuringWorkingDays = () => {
+        const today = new Date();
+        const day = today.getDay();
+        return day < 6;
+    }
+
+    const isDuringWorkingHours = () => {
+        const today = new Date();
+        const hours = today.getHours();
+        return hours >= 8 && hours <= 18;
+    }
+
     it('als gebruiker zie ik de globale footer van Vlaanderen', async () => {
-        const footer = await vlFooterPage.getFooter();
+        if (isDuringWorkingDays() && isDuringWorkingHours()) { // DEV servers of AIV uptime check
+            const footer = await vlFooterPage.getFooter();
         await assert.eventually.isTrue(footer.isDisplayed());
+        }
     });
 });


### PR DESCRIPTION
De AIV ontwikkel servers zijn alleen maar up and running tijdens de kantooruren, dus kunnen we onze E2E testen alleen maar dan draaien.